### PR TITLE
fix a bug in the search_engine method

### DIFF
--- a/glpi/glpi.py
+++ b/glpi/glpi.py
@@ -737,7 +737,7 @@ class GLPI(object):
             # build searchtype argument
             # -> optional! defaults to "contains" on the server if empty
             if 'searchtype' in c and c['searchtype'] is not None:
-                uri = (uri + "&criteria[%d][searchtype]=%s".format(idx,
+                uri = (uri + "&criteria[%d][searchtype]=%s" % (idx,
                        c['searchtype']))
             else:
                 uri = uri + "&criteria[%d][searchtype]=" % (idx)


### PR DESCRIPTION
this bug made `search_engine` method virtually unusable, because it generated incorrect search URL.

made `%` instead of `format` function, as everywhere else in the code.