### PR TITLE
make GlpiService.request use json parameter

### DIFF
--- a/glpi/glpi.py
+++ b/glpi/glpi.py
@@ -324,7 +324,7 @@ class GlpiService(object):
         try:
             response = requests.request(method=method, url=full_url,
                                         headers=headers, params=params,
-                                        data=data, **kwargs)
+                                        data=data, json=json,**kwargs)
         except Exception:
             logger.error("ERROR requesting uri(%s) payload(%s)" % (url, data))
             raise


### PR DESCRIPTION
so it would be possible to make "low-level" requests. for instance, [assign users to ticket](https://forum.glpi-project.org/viewtopic.php?pid=340693#p340693) is impossible, if you use `data` parameter instead of `json`, because `PreparedRequest.prepare_body` messes up arrays.